### PR TITLE
Ensuring footnote content box has width 100%

### DIFF
--- a/src/templates/common/_css/franklin.css
+++ b/src/templates/common/_css/franklin.css
@@ -175,7 +175,8 @@ html {
     padding-left: 5px;}
 .franklin-content .fndef td.fndef-content {
     font-size: 80%;
-    padding-left: 10px;}
+    padding-left: 10px;
+    width: 100%;}
 
 /* ==================================================================
     IMAGES in CONTENT


### PR DESCRIPTION
This PR fixes a layout issue where footnotes with different lengths had different sized bounding boxes for the content and the footnote number. Now, the footnote number boxes are all uniformly aligned.

[slack discussion](https://julialang.slack.com/archives/CTXP36PR6/p1601178855010100)

Before:

![different-starts](https://user-images.githubusercontent.com/6856636/94768874-7dacf800-0365-11eb-8d87-2f6d8c844ac6.png)

Now:
![all_aligned_new](https://user-images.githubusercontent.com/6856636/94771603-75a48680-036c-11eb-9c6c-6a0e17e3562d.png)

