### PR TITLE
Allow display equations to wrap on small screens

### DIFF
--- a/src/templates/common/_css/franklin.css
+++ b/src/templates/common/_css/franklin.css
@@ -201,7 +201,10 @@ body { counter-reset: eqnum; }
 .katex { font-size: 1em !important; }
 
 .katex-display .katex {
-    display: inline-block; } /* overwrite katex settings */
+    /* Overwrite KaTeX settings. */
+    display: inline-block; 
+    /* Allow display equations to wrap on small screens. */
+    white-space: normal; }
 
 .katex-display::after {
     counter-increment: eqnum;


### PR DESCRIPTION
Google Search Console keeps pestering me with "errors" (I use *pestering* since the site works, so it should not be called an *error*). Now, the larger font size caused some display equations to be too big for mobile. This PR should fix that problem since it will allow wrapping on small screens. 

Note that the fix doesn't fix the resulting 
- misalignment of the equation number and 
- the quite tight line-spacing for the wrapped element

Both are not too bad, I'd say. 