### PR TITLE
RFC: Switch menu1 to newer syntax

### DIFF
--- a/src/templates/common/menu1.md
+++ b/src/templates/common/menu1.md
@@ -1,8 +1,9 @@
-@def title = "Code blocks"
-@def hascode = true
-@def date = Date(2019, 3, 22)
-@def rss = "A short description of the page which would serve as **blurb** in a `RSS` feed; you can use basic markdown here but the whole description string must be a single line (not a multiline string). Like this one for instance. Keep in mind that styling is minimal in RSS so for instance don't expect maths or fancy styling to work; images should be ok though: ![](https://upload.wikimedia.org/wikipedia/en/3/32/Rick_and_Morty_opening_credits.jpeg)"
-
++++
+title = "Code blocks"
+hascode = true
+date = Date(2019, 3, 22)
+rss = "A short description of the page which would serve as **blurb** in a `RSS` feed; you can use basic markdown here but the whole description string must be a single line (not a multiline string). Like this one for instance. Keep in mind that styling is minimal in RSS so for instance don't expect maths or fancy styling to work; images should be ok though: ![](https://upload.wikimedia.org/wikipedia/en/3/32/Rick_and_Morty_opening_credits.jpeg)"
++++
 @def tags = ["syntax", "code"]
 
 # Working with code blocks


### PR DESCRIPTION
I was creating a new website and noticed that `menu1.md`, `menu2.md`, et cetera. use `@def`. 

@tlienart How about making the +++ syntax the default like shown in this PR for `menu1.md`?