### PR TITLE
Use buildpackage

### DIFF
--- a/src/templates/common/.github/workflows/Deploy.yml
+++ b/src/templates/common/.github/workflows/Deploy.yml
@@ -27,11 +27,10 @@ jobs:
     - name: Install dependencies listed in Project.toml and build package
       uses: julia-actions/julia-buildpkg@master
     # NOTE
-    #   Using --project below ensures that NodeJS and Franklin are loaded then 
-    #   it installs highlight.js which is needed for the prerendering step
+    #   Using --project below ensures that the environment defined by
+    #   Project.toml and build by `julia-buildpkg` is loaded. Then, it 
+    #   installs highlight.js which is needed for the prerendering step 
     #   (code highlighting + katex prerendering).
-    #   Then, the environment is activated and instantiated to install all
-    #   Julia packages which may be required to successfully build your site.
     #   The last line should be `optimize()` though you may want to give it
     #   specific arguments, see the documentation or ?optimize in the REPL.
     - run: julia --project -e '

--- a/src/templates/common/.github/workflows/Deploy.yml
+++ b/src/templates/common/.github/workflows/Deploy.yml
@@ -35,7 +35,7 @@ jobs:
     #   specific arguments, see the documentation or ?optimize in the REPL.
     - run: julia --project -e '
             using NodeJS; run(`$(npm_cmd()) install highlight.js`);
-            using Franklin; 
+            using Franklin;
             optimize()'
     - name: Build and Deploy
       uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/src/templates/common/.github/workflows/Deploy.yml
+++ b/src/templates/common/.github/workflows/Deploy.yml
@@ -24,18 +24,19 @@ jobs:
       uses: julia-actions/setup-julia@v1
       with:
         version: 1.5
+    - name: Install dependencies listed in Project.toml and build package
+      uses: julia-actions/julia-buildpkg@master
     # NOTE
-    #   The steps below ensure that NodeJS and Franklin are loaded then it
-    #   installs highlight.js which is needed for the prerendering step
+    #   Using --project below ensures that NodeJS and Franklin are loaded then 
+    #   it installs highlight.js which is needed for the prerendering step
     #   (code highlighting + katex prerendering).
-    #   Then the environment is activated and instantiated to install all
+    #   Then, the environment is activated and instantiated to install all
     #   Julia packages which may be required to successfully build your site.
     #   The last line should be `optimize()` though you may want to give it
     #   specific arguments, see the documentation or ?optimize in the REPL.
-    - run: julia -e '
-            using Pkg; Pkg.activate("."); Pkg.instantiate();
+    - run: julia --project -e '
             using NodeJS; run(`$(npm_cmd()) install highlight.js`);
-            using Franklin;
+            using Franklin; 
             optimize()'
     - name: Build and Deploy
       uses: JamesIves/github-pages-deploy-action@releases/v3


### PR DESCRIPTION
I noticed that we can replace 
```
using Pkg; Pkg.activate("."); Pkg.instantiate();
```
by just using the `--project` flag if we also run 
```
uses: julia-actions/julia-buildpkg@master
```
Also, I've capitalized the filename `deploy.yml` because that appears to be the convention in Julia. For example, see https://github.com/JuliaRegistries/CompatHelper.jl.