### PR TITLE
Make second level of toc be alphanumeric

### DIFF
--- a/src/templates/common/_css/franklin.css
+++ b/src/templates/common/_css/franklin.css
@@ -153,6 +153,10 @@ h6 {
   text-align: center;
 }
 
+ol ol {
+  list-style-type: lower-alpha;
+}
+
 .franklin-content th,
 td {
   font-size: var(--small);

--- a/src/templates/common/_css/franklin.css
+++ b/src/templates/common/_css/franklin.css
@@ -153,7 +153,7 @@ h6 {
   text-align: center;
 }
 
-ol ol {
+.franklin-toc ol ol {
   list-style-type: lower-alpha;
 }
 


### PR DESCRIPTION
This is a very minor change: The table of contents looks kind of weird with the nested numbers:
```
1. Introduction
2. My story
   1. Houses
   2. Bikes
3. Conclusion
```
This PR changes the table of contents to
```
1. Introduction
2. My story
   a. Houses
   b. Bikes
3. Conclusion
```
I say table of contents because I couldn't find other locations where `ol` is used. Alternatively, I can change the code to something like
```
.franklin-toc ol ol { 
  ...
}
```