### PR TITLE
Use pkgdir instead of dirname(dirname(pathof(Foo)))

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -123,4 +123,4 @@ begin
     write(joinpath(build, "index.html"), take!(html))
 end
 
-cd(dirname(dirname(pathof(FranklinTemplates))))
+cd(pkgdir(FranklinTemplates))


### PR DESCRIPTION
I found a new method in Julia.base :partying_face: and remembered that I also could have used it here.

```
julia> using DataFrames

julia> pathof(DataFrames)
"/home/rik/.julia/packages/DataFrames/oQ5c7/src/DataFrames.jl"

julia> dirname(dirname(pathof(DataFrames)))
"/home/rik/.julia/packages/DataFrames/oQ5c7"

julia> pkgdir(DataFrames)
"/home/rik/.julia/packages/DataFrames/oQ5c7"
```