### PR TITLE
remove CLS

### DIFF
--- a/src/templates/vela/_layout/nav.html
+++ b/src/templates/vela/_layout/nav.html
@@ -1,4 +1,4 @@
-<div class="main-nav" id="menu">
+<div class="main-nav slideout-menu slideout-menu-left" id="menu">
   <div class="flex-container">
     <span class="sidebar-brand">
       <h3 style='font-size: 25px'>Vela Template</h3>
@@ -19,7 +19,7 @@
   </nav>
 </div> <!-- main nav menu -->
 
-<main id="panel">
+<main id="panel" class="slidout-panel slideout-panel-left">
   <div class="toggle-button hamburger hamburger--spin">
     <div class="hamburger-box">
       <div class="hamburger-inner"></div>


### PR DESCRIPTION
This fix should remove the cumulative layout shift by setting the classes directly instead of them getting later added by javascript.