### PR TITLE
a slightly better \col

### DIFF
--- a/src/templates/common/index.md
+++ b/src/templates/common/index.md
@@ -106,7 +106,7 @@ and use it \bolditalic{here for example}.
 
 Here's another quick one, a command to change the color:
 
-\newcommand{\col}[2]{~~~<span style="color:#1">#2</span>~~~}
+\newcommand{\col}[2]{~~~<span style="color:#1">~~~#2~~~</span>~~~}
 
 This is \col{blue}{in blue} or \col{#bf37bc}{in #bf37bc}.
 


### PR DESCRIPTION
### Originally `\col{GD update $x_{t+1} = x_t - \alpha \nabla f(x_t)$` look like this
![image](https://user-images.githubusercontent.com/22112456/133541005-5e2ad287-d227-437e-927e-68b1d8d4b98a.png)
katex rendering is blocked.

### what I did
I turn 
`\newcommand{\col}[2]{~~~<span style="color:#1">#2</span>~~~}`
into
`\newcommand{\col}[2]{~~~<span style="color:#1">~~~#2~~~</span>~~~}`


### Now
![image](https://user-images.githubusercontent.com/22112456/133540914-617a94ef-ff1a-4fbf-aea4-5a798e8c6d11.png)
This is much more useful and friendly to  LaTeX users.


I am not quite sure whether I am doing it right since I don't fully understand the difference between `#1` and `!#1`.