### PR TITLE
Switch to CC license in footer

### DIFF
--- a/src/templates/common/_layout/page_foot.html
+++ b/src/templates/common/_layout/page_foot.html
@@ -1,5 +1,4 @@
 <div class="page-foot">
-  <div class="copyright">
-    &copy; {{ fill author }}. {{isnotpage /tag/*}}Last modified: {{ fill fd_mtime }}.{{end}} Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the <a href="https://julialang.org">Julia programming language</a>.
-  </div>
+    <a href="http://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> {{ fill author }}. {{isnotpage /tag/*}}Last modified: {{ fill fd_mtime }}.{{end}}
+    Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the <a href="https://julialang.org">Julia programming language</a>.
 </div>


### PR DESCRIPTION
This PR suggests to change the default footer license to creative commons.

I've also removed the nested div which didn't do anything. To style the footer, `page-foot` can be used. I've checked this change against all templates and didn't see any out of the ordinary. Also, a search in CSS files for "copyright" didn't give many results:

```bash
~/git/FranklinTemplates.jl (rh/creative-commons) $ rg -t=css 'copyright'
src/templates/minimal-mistakes/_css/minimal-mistakes.css
2587:.page__footer-copyright {
```