### PR TITLE
Set `permissions: write-all` in template

### DIFF
--- a/src/templates/common/.github/workflows/Deploy.yml
+++ b/src/templates/common/.github/workflows/Deploy.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -23,7 +24,7 @@ jobs:
     - name: Install Julia
       uses: julia-actions/setup-julia@v1
       with:
-        version: 1.6
+        version: '1' # Latest stable Julia release.
     # NOTE
     #   The steps below ensure that NodeJS and Franklin are loaded then it
     #   installs highlight.js which is needed for the prerendering step


### PR DESCRIPTION
Setting `permissions: write-all` is required in new repositories for the `GITHUB_TOKEN` to work. See also https://github.com/JuliaDocs/Documenter.jl/pull/1819.

Without it, people might get an error like
```
fatal: unable to access 'https://github.com/rikhuijzer/MyProject.jl.git/': The requested URL returned error: 403
```