### PR TITLE
Update old urls

### DIFF
--- a/src/templates/common/menu1.md
+++ b/src/templates/common/menu1.md
@@ -36,7 +36,7 @@ You can now show what this would look like:
 * you don't have to specify the `.jl` (see below),
 * you do need to explicitly use print statements or `@show` for things to show, so just leaving a variable at the end like you would in the REPL will show nothing,
 * only Julia code blocks are supported at the moment, there may be a support for scripting languages like `R` or `python` in the future,
-* the way you specify the path is important; see [the docs](https://tlienart.github.io/franklindocs/code/index.html#more_on_paths) for more info. If you don't care about how things are structured in your `/assets/` folder, just use `./scriptname.jl`. If you want things to be grouped, use `./group/scriptname.jl`. For more involved uses, see the docs.
+* the way you specify the path is important; see [the docs](https://franklinjl.org/code/#more_on_paths) for more info. If you don't care about how things are structured in your `/assets/` folder, just use `./scriptname.jl`. If you want things to be grouped, use `./group/scriptname.jl`. For more involved uses, see the docs.
 
 Lastly, it's important to realise that if you don't change the content of the code, then that code will only be executed _once_ even if you make multiple changes to the text around it.
 
@@ -81,6 +81,6 @@ these scripts can be run in such a way that their output is also saved to file, 
 
 which is convenient if you're presenting code.
 
-**Note**: paths specification matters, see [the docs](https://tlienart.github.io/franklindocs/code/index.html#more_on_paths) for details.
+**Note**: paths specification matters, see [the docs](https://franklinjl.org/code/#more_on_paths) for details.
 
 Using this approach with the `generate_results.jl` file also makes sure that all the code on your website works and that all results match the code which makes maintenance easier.


### PR DESCRIPTION
I found some old urls to https://github.com/tlienart/franklindocs.

I also noticed that the following URLs are also invalid, but I couldn't find the correct link.

>See [how they defined it](https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/website/utils.jl).

https://github.com/tlienart/FranklinTemplates.jl/blob/4f32e2198efd77d635fbafccd40531496825c6c8/src/templates/common/menu2.md