### PR TITLE
Fix just-the-docs css

### DIFF
--- a/src/templates/just-the-docs/_css/jtd.css
+++ b/src/templates/just-the-docs/_css/jtd.css
@@ -647,4 +647,3 @@ franklin-toc {
   /* Avoid clickable elements being too close together. */
   margin: 0.6rem 0;
 }
-}

--- a/src/templates/just-the-docs/_css/jtd.css
+++ b/src/templates/just-the-docs/_css/jtd.css
@@ -435,7 +435,7 @@ MAIN CONTENT
   }
 }
 
-.main-footer {
+.page-foot {
   font-size: 14px;
   color: darkgray;
   border-top: 1px solid #eeebee;


### PR DESCRIPTION
* Remove unnecessary `}`
* Replace `main_footer` with `page-foot` in `jtd.css`